### PR TITLE
Update sublib.py

### DIFF
--- a/sublib/sublib.py
+++ b/sublib/sublib.py
@@ -226,7 +226,7 @@ class SubRip(Subtitle):
             line[0] = line[0][:len(line[0]) - 3]
             line[1] = line[1][:len(line[1]) - 3]
             line[2] = line[2].replace("|", "\n")
-        self.content = [f"{num}\n{line[0]} --> {line[1]}\n{line[2]}\n"
+        self.content = [f"{num}\n{line[0]} --> {line[1]}\n{line[2]}\n\n"
                         for num, line in enumerate(lines, 1)]
 
 


### PR DESCRIPTION
There should be an empty line between the entries.

Example:
```
1
00:00:04,112 --> 00:00:05,884
Previously on Billions.

2
00:00:05,919 --> 00:00:07,209
I want to introduce the chairman of
```

Instead of:
```
1
00:00:04,112 --> 00:00:05,884
Previously on Billions.
2
00:00:05,919 --> 00:00:07,209
I want to introduce the chairman of
```

(I saved the content like this:)
```python
    empty_subtitle = sublib.SubRip()
    empty_subtitle.set_from_general_format(general)
    lines = empty_subtitle.content
    with open(str(input).replace('.srt', '.out.srt'), 'w', encoding='utf-8') as out:
        out.writelines(lines)
```

