### PR TITLE
Handle broken lines in TMPlayer subs

### DIFF
--- a/sublib/sublib.py
+++ b/sublib/sublib.py
@@ -427,6 +427,12 @@ class TMPlayer(Subtitle):
         """
         lines = [line.rstrip("\n") for line in self.content]
         lines = [line.split(":", 3) for line in lines]
+        for idx, line in enumerate(lines):
+            if len(line) < 4:
+                raise IndexError(
+                    f"Please fix line #{idx} as it doesn't adhere to TMPlayer "
+                    f"format: '%H:%M:%S:text' -> {line}"
+                )
         lines = [
             [f"{line[0]}:{line[1]}:{line[2]}", line[3]]
             for line in lines

--- a/tests/test_tmplayer.py
+++ b/tests/test_tmplayer.py
@@ -49,3 +49,21 @@ class TestTMPlayerClass:
         subtitle = sublib.TMPlayer()
         subtitle.set_from_general_format(self.general_lines)
         assert test_data == subtitle.content
+
+    def test_tmplayer_invalid_line_format(self, mocker):
+        test_data = "00:01:00 Line 01"
+        mocker.patch(
+            "builtins.open",
+            mocker.mock_open(read_data=test_data)
+        )
+        subtitle = sublib.TMPlayer("file.txt", "utf-8")
+
+        with pytest.raises(IndexError) as exception_info:
+            subtitle.get_general_format()
+
+        expected_error_message = (
+            "Please fix line #0 as it doesn't adhere to TMPlayer "
+            f"format: '%H:%M:%S:text' -> {test_data.split(':', 3)}"
+        )
+        assert str(exception_info.value) == expected_error_message
+


### PR DESCRIPTION
Hi

Thank you for a great library.
When I tried to convert a `TMPlayer` sub to `SRT` I've noticed a following error:

```python
File ~/.virtualenvs/sublib/lib/python3.10/site-packages/sublib/sublib.py:431, in <listcomp>(.0)
    428 lines = [line.rstrip("\n") for line in self.content]
    429 lines = [line.split(":", 3) for line in lines]
    430 lines = [
--> 431     [f"{line[0]}:{line[1]}:{line[2]}", line[3]]
    432     for line in lines
    433 ]
    434 for line in lines:
    435     line[0] = datetime.datetime.strptime(line[0], "%H:%M:%S")

IndexError: list index out of range
```

It happened for a sub with a line that omitted 4th `:`, e.g.:
```txt
00:01:00 Line 01
```

I made a quick fix and added a basic unit test.

Thanks
